### PR TITLE
fix: Do not allocate an EIP if a VPC is provided

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -45,6 +45,6 @@ module "vpc" {
 }
 
 resource "aws_eip" "nat" {
-  count = 1
+  count = var.vpc_id == null ? 1 : 0
   vpc   = true
 }


### PR DESCRIPTION
Prevents the module from creating an unnecessary EIP in cases where a VPC is provided. Assumes the provided VPC's NAT Gateway(s) already have assigned EIPs, but letting this module create an EIP would not solve that, anyway.