### PR TITLE
fix: Only create cidr_rds_security_group when required

### DIFF
--- a/rds.tf
+++ b/rds.tf
@@ -24,7 +24,7 @@ resource "aws_db_instance" "postgres" {
   backup_window              = "10:00-11:00"
   backup_retention_period    = 21
   db_subnet_group_name       = var.database_subnet_group_name != null ? var.database_subnet_group_name : var.name
-  vpc_security_group_ids     = concat([aws_security_group.keycloak-security-group.id], var.proxy_instance ? [aws_security_group.cidr_rds_security_group.id] : [])
+  vpc_security_group_ids     = concat([aws_security_group.keycloak-security-group.id], var.proxy_instance ? [aws_security_group.cidr_rds_security_group[0].id] : [])
   storage_encrypted          = true
   auto_minor_version_upgrade = false # We recommend you do not upgrade the database version automatically, as it will put the database out-of-sync with the terraform.
 
@@ -72,6 +72,7 @@ resource "aws_security_group" "keycloak-security-group" {
 resource "aws_security_group" "cidr_rds_security_group" {
   name   = "${local.name}-cidr-rds-security-group"
   vpc_id = var.vpc_id == null ? module.vpc[0].vpc_id : var.vpc_id
+  count = var.proxy_instance ? 1 : 0
 
   ingress {
     from_port       = 5432

--- a/variables.tf
+++ b/variables.tf
@@ -224,7 +224,7 @@ variable "services" {
         ],
         "timeout" : 5,
         "interval" : 5,
-        "startPeriod" : 60
+        "startPeriod" : 120
       }
       mountPoints = null
       ulimits     = null


### PR DESCRIPTION
In an environment not utilizing the proxy ec2 instance, this resulted in a dangling security group.