### PR TITLE
phil/limit-vpc-version

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -16,7 +16,7 @@ module "vpc" {
 
   count   = var.vpc_id == null ? 1 : 0
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 5.1"
+  version = "~> 5.1, < 5.5"
 
   name = var.name
   cidr = var.cidr


### PR DESCRIPTION
5.5 release of vpc module was requiring a much newer version of the aws provider - this was forcing tf init to fail without the -upgrade flag, which would cause some issues for our managed customers and likely some on-prem customers